### PR TITLE
Clean Up AssemblyTools Init, Move Config Values to YAML

### DIFF
--- a/config/conntact_config.yaml
+++ b/config/conntact_config.yaml
@@ -1,0 +1,7 @@
+framework:
+  refresh_rate: 100
+algorithm: 
+  spiral_params:
+    frequency: 0.15 #Hz frequency in spiral_search_motion
+    min_amplitude: .002  #meters amplitude in spiral_search_motion
+    max_cycles: 62.83185 #2 * 3.14159 * 10 = 10 revolutions

--- a/config/peg_in_hole_params.yaml
+++ b/config/peg_in_hole_params.yaml
@@ -25,7 +25,7 @@ objects: #List objects and their required description
                     corner:
                         pose: [-3.5, -3.5, 50] #location relative to peg/hole local_part_pose being grasped
                         #grasp_name: "corner" #Used for angled search. Standardized so the corner of a rectangle will be presented.
-                        orientation: [35.26, -30, -9.74] #orientation relative to tcp
+                        orientation: [35.26, -30, -9.74] #orientation relative to tcp is 45 degrees in 2 rpy axes
                         #gripper_grasp_pose: [1, 2, 3] #Orientation relative to peg root frame. Robot solves path planning to reach this cartesian position
                         grasp_pressure: 50 #Percent maximum force
                         #friction: #Unsure how to format this. Should we assume the user has chosen grasps that have sufficient friction cones to control the graspable part?
@@ -200,3 +200,9 @@ assembled_state: #List the desired assembled state
         position: [1, 2, 3] #Trasformation from peg.local_part_pose relative to chosen Newtonian inertial frame
     hole: 
         position: [1, 2, 3] #Transformation from hole.local_part_pose relative to chosen Newtonian inertial frame
+task:
+    target_peg: "peg_10mm"
+    target_hole: "hole_10mm"
+    starting_tcp: "tip"
+    assumed_starting_height: 0.0
+    restart_height: -0.1

--- a/launch/ur10e_upload_compliance.launch
+++ b/launch/ur10e_upload_compliance.launch
@@ -2,8 +2,9 @@
 
 <launch>
   <!--  todo:Change this to happen in source code instead-->
-  <arg name="algorithm_selected" default="spiral_search_node" doc="Select the algorythm to be used: SpiralSearch or CornerSearch"/>
+  <arg name="algorithm_selected" default="spiral_search_node" doc="Select the algorithm to be used: SpiralSearch or CornerSearch"/>
   <rosparam file="$(find conntact)/config/peg_in_hole_params.yaml" />
+  <rosparam file="$(find conntact)/config/conntact_config.yaml" />
   <remap from="/wrench" to="/cartesian_compliance_controller/ft_sensor_wrench"/>
 
   <include file="$(find ur_robot_driver)/launch/ur10e_bringup.launch" >

--- a/src/conntact/assembly_algorithm_blocks.py
+++ b/src/conntact/assembly_algorithm_blocks.py
@@ -170,7 +170,7 @@ class AlgorithmBlocks(AssemblyTools):
             exec(method_name)
         except (NameError, AttributeError):
             rospy.logerr_throttle(2, "State name " + method_name + " does not match 'state_'+(state loop method name) in algorithm!")
-            pass
+            pass    
         except:
             print("Unexpected error when trying to locate state loop name:", sys.exc_info()[0])
             raise
@@ -232,7 +232,8 @@ class AlgorithmBlocks(AssemblyTools):
 
         seeking_force = 7.0
         self.wrench_vec  = self.get_command_wrench([0,0,seeking_force])
-        self.pose_vec = self.spiral_search_basic_compliance_control()
+        self.pose_vec = self.spiral_search_motion(self._spiral_params["frequency"], 
+            self._spiral_params["min_amplitude"], self._spiral_params["max_cycles"])
 
         if(not self.force_cap_check(*self.cap_check_forces)):
             self.next_trigger, self.switch_state = self.post_action(SAFETY_RETRACTION_TRIGGER) 


### PR DESCRIPTION
Added Conntact_Config.yaml; Organized AssemblyTools class member instantiation; all constants are now drawn from Conntact_Config; Renaming and cleanup of "spiral_search_motion" method, and changed to rely on yaml params. Tested on hardware; runs properly on Spiral Search or Corner Search.